### PR TITLE
Add necessary quotes for the ffmpeg branding option passed to gn

### DIFF
--- a/recipes-browser/chromium/chromium-browser-gn.inc
+++ b/recipes-browser/chromium/chromium-browser-gn.inc
@@ -119,7 +119,7 @@ EXTRA_OEGN = " \
         linux_use_bundled_binutils=false \
         use_gold=true \
         ${@bb.utils.contains('PACKAGECONFIG', 'component-build', 'is_component_build=true', 'is_component_build=false', d)} \
-        ${@bb.utils.contains('PACKAGECONFIG', 'proprietary-codecs', 'proprietary_codecs=true ffmpeg_branding=Chrome', 'proprietary_codecs=false', d)} \
+        ${@bb.utils.contains('PACKAGECONFIG', 'proprietary-codecs', 'proprietary_codecs=true ffmpeg_branding=\\\"Chrome\\\"', 'proprietary_codecs=false', d)} \
         use_ozone=true \
         ozone_auto_platforms=false \
         ozone_platform_headless=true \


### PR DESCRIPTION
String parameters passed to arguments of gn need to be properly quoted so do the same as what is done for 'ozone_platform' and other settings for 'ffmpeg_branding'.