### PR TITLE
Add a workaround patch that allows to hide menu windows in weston < 1.12

### DIFF
--- a/recipes-browser/chromium/chromium/chromium-wayland/0001-Fix-wayland-window-show-hide.patch
+++ b/recipes-browser/chromium/chromium/chromium-wayland/0001-Fix-wayland-window-show-hide.patch
@@ -1,0 +1,86 @@
+From 05c0be3bc856ec56a699aa346d0895dfe4a16032 Mon Sep 17 00:00:00 2001
+From: Maksim Sisov <msisov@igalia.com>
+Date: Thu, 8 Jun 2017 16:20:26 +0300
+Subject: [PATCH] Fix-wayland-window-show-hide
+
+---
+ ui/ozone/platform/wayland/wayland_window.cc | 26 +++++++++++++++++++-------
+ ui/ozone/platform/wayland/wayland_window.h  |  2 ++
+ 2 files changed, 21 insertions(+), 7 deletions(-)
+
+diff --git a/ui/ozone/platform/wayland/wayland_window.cc b/ui/ozone/platform/wayland/wayland_window.cc
+index 6775c75..2b0db7d 100644
+--- a/ui/ozone/platform/wayland/wayland_window.cc
++++ b/ui/ozone/platform/wayland/wayland_window.cc
+@@ -52,13 +52,8 @@ WaylandWindow* WaylandWindow::FromSurface(wl_surface* surface) {
+ }
+ 
+ bool WaylandWindow::Initialize() {
+-  surface_.reset(wl_compositor_create_surface(connection_->compositor()));
+-  if (!surface_) {
+-    LOG(ERROR) << "Failed to create wl_surface";
++  if (!CreateSurfaceAndSetUserData())
+     return false;
+-  }
+-  wl_surface_set_user_data(surface_.get(), this);
+-
+   // There is now default initialization for this type. Initialize it
+   // to ::WINDOW here. It will be changed by delelgate if it know the
+   // type of the window.
+@@ -111,6 +106,9 @@ void WaylandWindow::ApplyPendingBounds() {
+ 
+ void WaylandWindow::CreatePopupWindow() {
+   DCHECK(parent_window_);
++  if (!CreateSurfaceAndSetUserData())
++    return;
++
+   gfx::Rect bounds =
+       TranslateBoundsToScreenCoordinates(bounds_, parent_window_->GetBounds());
+   xdg_popup_.reset(xdg_shell_get_xdg_popup(
+@@ -119,6 +117,17 @@ void WaylandWindow::CreatePopupWindow() {
+   xdg_popup_add_listener(xdg_popup_.get(), &xdg_popup_listener, this);
+ }
+ 
++bool WaylandWindow::CreateSurfaceAndSetUserData() {
++  if (!surface_)
++    surface_.reset(wl_compositor_create_surface(connection_->compositor()));
++  if (!surface_) {
++    LOG(ERROR) << "Failed to create wl_surface";
++    return false;
++  }
++  wl_surface_set_user_data(surface_.get(), this);
++  return true;
++}
++
+ // TODO(msisov, tonikitoo): we will want to trigger show and hide of all
+ // windows once we pass minimize events from chrome.
+ void WaylandWindow::Show() {
+@@ -135,8 +144,11 @@ void WaylandWindow::Show() {
+ void WaylandWindow::Hide() {
+   if (child_window_)
+     child_window_->Hide();
+-  if (xdg_popup_)
++  if (xdg_popup_) {
++    wl_surface_attach(surface_.get(), NULL, 0, 0);
++    wl_surface_commit(surface_.get());
+     xdg_popup_.reset();
++  }
+ }
+ 
+ void WaylandWindow::Close() {
+diff --git a/ui/ozone/platform/wayland/wayland_window.h b/ui/ozone/platform/wayland/wayland_window.h
+index 387b3d3..61c18a1 100644
+--- a/ui/ozone/platform/wayland/wayland_window.h
++++ b/ui/ozone/platform/wayland/wayland_window.h
+@@ -97,6 +97,8 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
+   // Creates a popup window, which is visible as a menu window.
+   void CreatePopupWindow();
+ 
++  bool CreateSurfaceAndSetUserData();
++
+   PlatformWindowDelegate* delegate_;
+   WaylandConnection* connection_;
+   WaylandWindow* parent_window_ = nullptr;
+-- 
+2.1.4
+

--- a/recipes-browser/chromium/chromium_20170606.r473169.git9f55c5b.bb
+++ b/recipes-browser/chromium/chromium_20170606.r473169.git9f55c5b.bb
@@ -14,11 +14,11 @@ SRC_URI = "\
         ${@bb.utils.contains('PACKAGECONFIG', 'disable-api-keys-info-bar', 'file://api-keys.patch;patchdir=${WORKDIR}', '', d)} \
         file://google-chrome.desktop \
         file://0004-Create-empty-i18n_process_css_test.html-file-to-avoi.patch \
+        file://chromium-wayland/0001-Fix-wayland-window-show-hide.patch \
         ${@bb.utils.contains('PACKAGECONFIG', 'ignore-lost-context', 'file://0001-Remove-accelerated-Canvas-support-from-blacklist.patch', '', d)} \
 "
 
 S = "${WORKDIR}/src"
-
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0fca02217a5d49a14dfe2d11837bb34d"
 SRC_URI[md5sum] = "ae8966cde764bb4cc783286025171931"


### PR DESCRIPTION
buffer has to be detached from the surface, which leads weston/wayland to hide window. 