### PR TITLE
fixup! [ozone/wayland] Add backspace support for IME.

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland_67.0.3375.0.r543955.igalia.1.bb
+++ b/recipes-browser/chromium/chromium-ozone-wayland_67.0.3375.0.r543955.igalia.1.bb
@@ -4,14 +4,15 @@ require chromium-gn.inc
 SRC_URI += " \
  file://0001-ozone-wayland-Explicitly-release-capture-of-destroye.patch \
  file://0001-Fix-kiosk-and-start-maximized-modes-in-AGL.patch \
- file://0001-Rotate-gcc-toolchain-s-build-flags.patch \ 
+ file://0001-Rotate-gcc-toolchain-s-build-flags.patch \
  file://0001-Fix-Assignment-had-no-effect.patch \
  file://0001-GCC-use-Wformat-for-openh264.patch \
  file://0001-Use-SK_ARM_HAS_NEON-guard-in-skia-for-float-instruct.patch;patchdir=third_party/skia \
  file://0001-GCC-fix-size_t-does-not-name-a-type.patch;patchdir=third_party/angle \
  file://0001-third_party-Make-it-possible-to-build-chromium-with-.patch \
- file://0001-ozone-wayland-IME-Handle-backspace-button.patch \
- file://0001-fixup-ozone-wayland-IME-Handle-backspace-button.patch \
+ file://ime-support/0001-ozone-wayland-IME-Handle-backspace-button.patch \
+ file://ime-support/0001-fixup-ozone-wayland-IME-Handle-backspace-button.patch \
+ file://ime-support/0001-fixup-again-ozone-wayland-IME-Handle-backspace-butto.patch \
 "
 
 REQUIRED_DISTRO_FEATURES = "wayland"

--- a/recipes-browser/chromium/files/ime-support/0001-fixup-again-ozone-wayland-IME-Handle-backspace-butto.patch
+++ b/recipes-browser/chromium/files/ime-support/0001-fixup-again-ozone-wayland-IME-Handle-backspace-butto.patch
@@ -1,0 +1,27 @@
+From 5600205eec2b71b778dfa55a430e1e9ba246d552 Mon Sep 17 00:00:00 2001
+From: Julie Jeongeun Kim <jkim@igalia.com>
+Date: Thu, 12 Jul 2018 18:34:14 +0900
+Subject: [PATCH] fixup! again, [ozone/wayland/IME] Handle backspace button.
+
+Fixed compilation error.
+linux_input_method_context.h:47:46: error: 'Range' in namespace
+'gfx' does not name a type
+---
+ ui/base/ime/linux/linux_input_method_context.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ui/base/ime/linux/linux_input_method_context.h b/ui/base/ime/linux/linux_input_method_context.h
+index de3beca702a6..094c06383395 100644
+--- a/ui/base/ime/linux/linux_input_method_context.h
++++ b/ui/base/ime/linux/linux_input_method_context.h
+@@ -11,6 +11,7 @@
+ 
+ namespace gfx {
+ class Rect;
++class Range;
+ }
+ 
+ namespace ui {
+-- 
+2.14.1
+


### PR DESCRIPTION
It fixed the path for IME patches and appended additional fixup
patch.